### PR TITLE
Use DER/PEM encoding when appropriate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "async-stream"
@@ -55,6 +55,7 @@ dependencies = [
 name = "auraed"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "futures",
  "h2",
@@ -62,6 +63,7 @@ dependencies = [
  "multi_log",
  "prost",
  "rustls",
+ "rustls-pemfile",
  "simplelog",
  "syslog",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ tokio = { version = "1.0", features = ["macros", "fs", "rt-multi-thread"] }
 futures = "0.3.23"
 h2 = "0.3.13"
 rustls = "0.20.6"
+anyhow = "1.0.65"
+rustls-pemfile = "1.0.1"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 all: compile
 
 executable   ?=  auraed
-cargo         =  cargo +nightly
+cargo         =  cargo
 apibranch     =  main
 
 .PHONY: api


### PR DESCRIPTION
WebPKI needs a DER encoded array, while rustls needs a PEM encoded array.