### PR TITLE
Removed unused TLS code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ futures = "0.3.23"
 h2 = "0.3.13"
 rustls = "0.20.6"
 anyhow = "1.0.65"
-rustls-pemfile = "1.0.1"
 
 [build-dependencies]
 tonic-build = "0.8"


### PR DESCRIPTION
RootCertStore is not being used, so configuring it is not needed.