### PR TITLE
Run clippy on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ cargo         =  cargo
 branch       ?=  main
 
 compile: ## Compile for the local architecture ⚙
+	@$(cargo) clippy
 	@$(cargo) build
 
 install: ## Build and install (debug) 🎉

--- a/build.rs
+++ b/build.rs
@@ -35,13 +35,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //Command::new("make").args(&["command"]).status().unwrap();
 
     // gRPC
-    tonic_build::configure().compile(
-        &[
-            "../api/v1/meta.proto",
-            "../api/v1/runtime.proto",
-            "../api/v1/observe.proto",
-        ],
-        &["../api/v1"],
-    )?;
+    tonic_build::configure()
+        .type_attribute(
+            "meta.AuraeMeta",
+            "#[allow(clippy::derive_partial_eq_without_eq)]",
+        )
+        .compile(
+            &[
+                "../api/v1/meta.proto",
+                "../api/v1/runtime.proto",
+                "../api/v1/observe.proto",
+            ],
+            &["../api/v1"],
+        )?;
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,6 +28,8 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
+#![warn(clippy::unwrap_used)]
+
 use auraed::*;
 use clap::Parser;
 use log::*;
@@ -76,11 +78,7 @@ async fn daemon() -> i32 {
     // Normal mode: Info, Warn, Error
     // Verbose mode: Debug, Trace, Info, Warn, Error
     // let logger_level = if matches.is_present("verbose") {
-    let logger_level = if options.verbose {
-        Level::Trace
-    } else {
-        Level::Info
-    };
+    let logger_level = if options.verbose { Level::Trace } else { Level::Info };
 
     // Syslog formatter
     let formatter = Formatter3164 {
@@ -91,10 +89,12 @@ async fn daemon() -> i32 {
     };
 
     // Initialize the logger
-    let logger_simple =
-        simplelog::SimpleLogger::new(logger_level.to_level_filter(), simplelog::Config::default());
+    let logger_simple = simplelog::SimpleLogger::new(
+        logger_level.to_level_filter(),
+        simplelog::Config::default(),
+    );
     let logger_syslog = syslog::unix(formatter).unwrap();
-    let _ = match multi_log::MultiLogger::init(
+    match multi_log::MultiLogger::init(
         vec![logger_simple, Box::new(BasicLogger::new(logger_syslog))],
         logger_level,
     ) {

--- a/src/observe/mod.rs
+++ b/src/observe/mod.rs
@@ -52,15 +52,11 @@ impl Observe for ObserveService {
         &self,
         _request: Request<StatusRequest>,
     ) -> Result<Response<StatusResponse>, Status> {
-        let mut meta = Vec::new();
-        meta.push(meta::AuraeMeta {
+        let meta = vec![meta::AuraeMeta {
             code: CODE_UNKNOWN,
             message: MESSAGE_UNKNOWN.into(),
-        });
-        let response = StatusResponse {
-            meta,
-            state: STATUS_UNKNOWN.into(),
-        };
+        }];
+        let response = StatusResponse { meta, state: STATUS_UNKNOWN.into() };
         Ok(Response::new(response))
     }
 }


### PR DESCRIPTION
Clippy has a default configuration, so it will output warnings for more than explicitly configured. This should be overridable, but starting with the defaults seems like a good choice.

You can see an example of where I needed to override clippy in the build.rs file.