### PR TITLE
Handle Power Button Event

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -30,6 +30,7 @@
 
 pub(crate) mod fileio;
 pub(crate) mod network;
+pub(crate) mod power;
 
 use log::{error, info, warn, Level};
 use std::ffi::CString;

--- a/src/init/network.rs
+++ b/src/init/network.rs
@@ -30,7 +30,7 @@
 
 use anyhow::anyhow;
 use futures::stream::TryStreamExt;
-use log::{error, info, warn, trace};
+use log::{error, info, trace, warn};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str;
@@ -38,8 +38,8 @@ use std::{cmp, fs, io};
 
 use ipnetwork::{Ipv4Network, Ipv6Network};
 
-use rtnetlink::Handle;
 use netlink_packet_route::rtnl::link::nlas::Nla;
+use rtnetlink::Handle;
 
 #[derive(Eq, PartialEq)]
 enum IpType {
@@ -63,7 +63,10 @@ pub fn get_sriov_capabilities(iface: &str) -> Result<String, io::Error> {
     ))
 }
 
-pub async fn set_link_up(handle: Handle, iface: &str) -> Result<(), anyhow::Error> {
+pub async fn set_link_up(
+    handle: Handle,
+    iface: &str,
+) -> Result<(), anyhow::Error> {
     let mut links = handle.link().get().match_name(iface.to_string()).execute();
 
     if let Some(link) = links.try_next().await? {
@@ -76,7 +79,10 @@ pub async fn set_link_up(handle: Handle, iface: &str) -> Result<(), anyhow::Erro
 }
 
 #[allow(dead_code)]
-pub async fn set_link_down(handle: Handle, iface: &str) -> Result<(), anyhow::Error> {
+pub async fn set_link_down(
+    handle: Handle,
+    iface: &str,
+) -> Result<(), anyhow::Error> {
     let mut links = handle.link().get().match_name(iface.to_string()).execute();
 
     if let Some(link) = links.try_next().await? {
@@ -131,20 +137,20 @@ pub fn setup_sriov(iface: &str, limit: u16) {
         return;
     }
 
-    let sriov_totalvfs = match get_sriov_capabilities(iface){
+    let sriov_totalvfs = match get_sriov_capabilities(iface) {
         Ok(val) => val,
         Err(e) => {
             error!("sriov Error: failed to get sriov capabilities of device {}. {}", iface, e);
-            return
-        }  
+            return;
+        }
     };
 
-    let sriov_totalvfs = match sriov_totalvfs.trim_end().parse::<u16>(){
+    let sriov_totalvfs = match sriov_totalvfs.trim_end().parse::<u16>() {
         Ok(val) => val,
         Err(e) => {
             error!("sriov Error: failed to parse sriov capabilities. {}", e);
-            return
-        }  
+            return;
+        }
     };
 
     let num = cmp::min(limit, sriov_totalvfs);
@@ -155,7 +161,6 @@ pub fn setup_sriov(iface: &str, limit: u16) {
     )
     .expect("Unable to write file");
 }
-
 
 pub async fn get_links(
     handle: rtnetlink::Handle,

--- a/src/init/power.rs
+++ b/src/init/power.rs
@@ -46,7 +46,6 @@ fn syscall_reboot(action: i32) {
     }
 }
 
-#[allow(dead_code)]
 pub fn power_off() {
     syscall_reboot(libc::LINUX_REBOOT_CMD_POWER_OFF);
 }
@@ -65,6 +64,9 @@ pub struct InputEvent {
     code: u16,
     value: u32,
 }
+
+const KEY_POWER: u16 = 116;
+
 
 #[allow(dead_code)]
 pub fn spawn_acpi_listener() {
@@ -88,6 +90,9 @@ pub fn spawn_acpi_listener() {
         match event_file.read(event_slice) {
             Ok(result) => {
                 info!("Event0: {} {:?}",result, event);
+                if event.code == KEY_POWER {
+                    power_off();
+                }
             }
             Err(e) => {
                 error!(

--- a/src/init/power.rs
+++ b/src/init/power.rs
@@ -1,0 +1,48 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+extern crate libc;
+
+#[allow(dead_code)]
+fn syscall_reboot(action: i32) {
+    unsafe {
+        libc::reboot(action);
+    }
+}
+
+#[allow(dead_code)]
+pub fn power_off() {
+    syscall_reboot(libc::LINUX_REBOOT_CMD_POWER_OFF);
+}
+
+#[allow(dead_code)]
+pub fn reboot() {
+    syscall_reboot(libc::LINUX_REBOOT_CMD_RESTART);
+}

--- a/src/init/power.rs
+++ b/src/init/power.rs
@@ -65,6 +65,7 @@ pub struct InputEvent {
     value: u32,
 }
 
+// see  https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/input-event-codes.h#L191
 const KEY_POWER: u16 = 116;
 
 
@@ -84,9 +85,8 @@ pub fn spawn_acpi_listener() {
 
 
     std::thread::spawn(move || loop {
-        unsafe {
-        let event_slice = slice::from_raw_parts_mut(&mut event as *mut _ as *mut u8, event_size);
-
+        let event_slice = unsafe {slice::from_raw_parts_mut(&mut event as *mut _ as *mut u8, event_size)};
+    
         match event_file.read(event_slice) {
             Ok(result) => {
                 info!("Event0: {} {:?}",result, event);
@@ -102,7 +102,7 @@ pub fn spawn_acpi_listener() {
                 );
             }
         }
-    }
+
     });
 
 }

--- a/src/init/power.rs
+++ b/src/init/power.rs
@@ -28,6 +28,15 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
+use log::{error, info, trace, warn};
+use std::{
+    fs::{self, read, OpenOptions},
+    io::Read,
+    mem,
+    path::Path,
+    slice,
+};
+
 extern crate libc;
 
 #[allow(dead_code)]
@@ -45,4 +54,50 @@ pub fn power_off() {
 #[allow(dead_code)]
 pub fn reboot() {
     syscall_reboot(libc::LINUX_REBOOT_CMD_RESTART);
+}
+
+#[derive(Debug, Default, Copy, Clone)]
+#[repr(C, packed)]
+pub struct InputEvent {
+    tv_sec: u64,
+    tv_usec: u64,
+    evtype: u16,
+    code: u16,
+    value: u32,
+}
+
+#[allow(dead_code)]
+pub fn spawn_acpi_listener() {
+    // TODO: detect power button devices
+    // devices are listed in /proc/bus/input/devices
+    let power_btn_device = Path::new("/dev/input/event0");
+
+    let mut file_options = OpenOptions::new();
+    file_options.read(true);
+    file_options.write(false);
+    let mut event_file = file_options.open(power_btn_device).unwrap();
+
+    let mut event: InputEvent = unsafe { mem::zeroed() };
+    let event_size = mem::size_of::<InputEvent>();
+
+
+    std::thread::spawn(move || loop {
+        unsafe {
+        let event_slice = slice::from_raw_parts_mut(&mut event as *mut _ as *mut u8, event_size);
+
+        match event_file.read(event_slice) {
+            Ok(result) => {
+                info!("Event0: {} {:?}",result, event);
+            }
+            Err(e) => {
+                error!(
+                    "Could not parse event from {}: {}",
+                    power_btn_device.display(),
+                    e
+                );
+            }
+        }
+    }
+    });
+
 }

--- a/src/init/power.rs
+++ b/src/init/power.rs
@@ -69,7 +69,7 @@ pub struct InputEvent {
 const KEY_POWER: u16 = 116;
 
 #[allow(dead_code)]
-pub fn spawn_acpi_listener() {
+pub fn spawn_power_button_listener() {
     // TODO: detect power button devices
     // - multiple power buttons are possible
     // - handle reboot button with a reboot instead

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,12 +186,6 @@ impl SystemRuntime {
 
         trace!("Configure filesystem");
         init_rootfs();
-        // Show content of file-based kernel interface directories
-        fileio::show_dir("/dev/input", false);
-        fileio::show_dir("/proc/acpi/", true);
-
-        //fileio::show_dir("/sys", false);
-        //fileio::show_dir("/proc", false);
 
         trace!("configure network");
         // Show available network interfaces

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use crate::init::fileio;
 use crate::init::network::set_link_up;
 use crate::init::network::{add_address_ipv4, add_address_ipv6};
-use crate::init::power::spawn_acpi_listener;
+use crate::init::power::spawn_power_button_listener;
 
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 
@@ -225,7 +225,7 @@ impl SystemRuntime {
         }
 
         show_network_info(handle).await;
-        spawn_acpi_listener();
+        spawn_power_button_listener();
 
         trace!("init of auraed as pid1 done");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,9 @@ use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 
-use crate::init::fileio;
 use crate::init::network::set_link_up;
 use crate::init::network::{add_address_ipv4, add_address_ipv6};
-use crate::init::power::spawn_power_button_listener;
+use crate::init::power::spawn_thread_power_button_listener;
 
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 
@@ -72,6 +71,18 @@ mod runtime;
 
 pub const AURAE_SOCK: &str = "/var/run/aurae/aurae.sock";
 pub const LOOPBACK_DEV: &str = "lo";
+
+pub const LOOPBACK_IPV6: &str = "::1";
+pub const LOOPBACK_IPV6_SUBNET: &str = "/128";
+
+pub const LOOPBACK_IPV4: &str = "127.0.0.1";
+pub const LOOPBACK_IPV4_SUBNET: &str = "/8";
+
+pub const DEFAULT_NET_DEV: &str = "eth0";
+pub const DEFAULT_NET_DEV_IPV6: &str = "fe80::2";
+pub const DEFAULT_NET_DEV_IPV6_SUBNET: &str = "/64";
+
+pub const POWER_BUTTON_DEVICE: &str = "/dev/input/event0";
 
 #[derive(Debug)]
 pub struct AuraedRuntime {
@@ -178,6 +189,17 @@ pub struct SystemRuntime {
 }
 
 impl SystemRuntime {
+
+    fn spawn_system_runtime_threads(&self){
+
+        // ---- MAIN DAEMON THREAD POOL ----
+        // TODO: https://github.com/aurae-runtime/auraed/issues/33
+        spawn_thread_power_button_listener(POWER_BUTTON_DEVICE);
+
+        // ---- MAIN DAEMON THREAD POOL ----
+    }
+
+
     async fn init_pid1(&self) {
         print_logo();
 
@@ -194,14 +216,18 @@ impl SystemRuntime {
         tokio::spawn(connection);
 
         trace!("configure {}", LOOPBACK_DEV);
-        if let Ok(ipv6) = "::1/128".parse::<Ipv6Network>() {
+        if let Ok(ipv6) = format!("{}{}", LOOPBACK_IPV6, LOOPBACK_IPV6_SUBNET)
+            .parse::<Ipv6Network>()
+        {
             if let Err(e) =
                 add_address_ipv6(LOOPBACK_DEV, ipv6, handle.clone()).await
             {
                 error!("{}", e);
             };
         };
-        if let Ok(ipv4) = "127.0.0.1/8".parse::<Ipv4Network>() {
+        if let Ok(ipv4) = format!("{}{}", LOOPBACK_IPV4, LOOPBACK_IPV4_SUBNET)
+            .parse::<Ipv4Network>()
+        {
             if let Err(e) =
                 add_address_ipv4(LOOPBACK_DEV, ipv4, handle.clone()).await
             {
@@ -213,19 +239,24 @@ impl SystemRuntime {
             error!("{}", e);
         }
 
-        trace!("configure eth0");
-        if let Ok(ipv6) = "fe80::2/64".parse::<Ipv6Network>() {
-            if let Err(e) = add_address_ipv6("eth0", ipv6, handle.clone()).await
+        trace!("configure {}", DEFAULT_NET_DEV);
+        if let Ok(ipv6) =
+            format!("{}{}", DEFAULT_NET_DEV_IPV6, DEFAULT_NET_DEV_IPV6_SUBNET)
+                .parse::<Ipv6Network>()
+        {
+            if let Err(e) =
+                add_address_ipv6(DEFAULT_NET_DEV, ipv6, handle.clone()).await
             {
                 error!("{}", e);
             }
         };
-        if let Err(e) = set_link_up(handle.clone(), "eth0").await {
+        if let Err(e) = set_link_up(handle.clone(), DEFAULT_NET_DEV).await {
             error!("{}", e);
         }
 
         show_network_info(handle).await;
-        spawn_power_button_listener();
+
+        self.spawn_system_runtime_threads();
 
         trace!("init of auraed as pid1 done");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@ impl SystemRuntime {
         }
 
         show_network_info(handle).await;
+        spawn_acpi_listener();
 
         trace!("init of auraed as pid1 done");
     }


### PR DESCRIPTION
Hi Community,

this PR adds a power button listener.

* Listen to power button events
* No libc required for listening to events
    * libc only used for reboot syscall (easy to replace) 


## Test
Run auraed in a VM as pid1:
```
make build-container
make kernel
make initramfs

# create `vm-br0` bridge on your machine:
make network

# run auraed in a VM as pid 1:
make virsh-start virsh-console virsh-stop

# exit VM console with Ctrl+]
```
Send a shutdown signal:
```
make virsh-shutdown 
# before the vm is powered off, a log entry shows the received input event
```




## Todos
* Notify Runtime first before shutting down - `.await` the auraed runtime
* detect correct power button input device (hardcoded to `/dev/input/event0` which works for the libvirtd development vm)
* Handle reboot button with a reboot instead