### PR TITLE
Reorganizing init module (first pass)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ sea-orm = { version = "^0.9.0", features = [ "sqlx-sqlite", "runtime-tokio-rustl
 ipnetwork = "0.20.0"
 rtnetlink = "0.11.0"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
+thiserror = "1.0.37"
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -78,10 +78,8 @@ async fn daemon() -> i32 {
     // let logger_level = if matches.is_present("verbose") {
     let logger_level = if options.verbose { Level::Trace } else { Level::Info };
 
-    let system = SystemRuntime { logger_level };
-
     // Initializes Logging and prepares system if auraed is run as pid=1
-    system.init().await;
+    init::init(logger_level).await;
 
     trace!("**Logging: Verbose Mode**");
     info!("Starting Aurae Daemon Runtime...");

--- a/src/init/fs.rs
+++ b/src/init/fs.rs
@@ -1,0 +1,81 @@
+use log::{error, info};
+use std::ffi::{CString, NulError};
+use std::ptr;
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum FsError {
+    #[error("{source_name} cannot be converted to a CString")]
+    InvalidSourceName { source_name: String, source: NulError },
+    #[error("{target_name} cannot be converted to a CString")]
+    InvalidTargetName { target_name: String, source: NulError },
+    #[error("{fstype} cannot be converted to a CString")]
+    InvalidFstype { fstype: String, source: NulError },
+    #[error("Failed to mount: source_name={source_name}, target_name={target_name}, fstype={fstype}")]
+    MountFailure { source_name: String, target_name: String, fstype: String },
+}
+
+pub(crate) fn mount_vfs(
+    source_name: &str,
+    target_name: &str,
+    fstype: &str,
+) -> Result<(), FsError> {
+    info!("Mounting {}", target_name);
+
+    // CString constructor ensures the trailing 0byte, which is required by libc::mount
+    let src_c_str =
+        CString::new(source_name).map_err(|e| FsError::InvalidSourceName {
+            source_name: source_name.to_owned(),
+            source: e,
+        })?;
+
+    let target_name_c_str =
+        CString::new(target_name).map_err(|e| FsError::InvalidTargetName {
+            target_name: target_name.to_owned(),
+            source: e,
+        })?;
+
+    let ret = {
+        #[cfg(not(target_os = "macos"))]
+        {
+            let fstype_c_str = CString::new(fstype).map_err(|e| {
+                FsError::InvalidFstype { fstype: fstype.to_owned(), source: e }
+            })?;
+
+            unsafe {
+                libc::mount(
+                    src_c_str.as_ptr(),
+                    target_name_c_str.as_ptr(),
+                    fstype_c_str.as_ptr(),
+                    0,
+                    ptr::null(),
+                )
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        unsafe {
+            libc::mount(
+                src_c_str.as_ptr(),
+                target_name_c_str.as_ptr(),
+                0,
+                ptr::null_mut(),
+            )
+        }
+    };
+
+    if ret < 0 {
+        error!("Failed to mount ({})", ret);
+        let error = CString::new("Error: ").expect("error creating CString");
+        unsafe {
+            libc::perror(error.as_ptr());
+        };
+
+        Err(FsError::MountFailure {
+            source_name: source_name.to_owned(),
+            target_name: target_name.to_owned(),
+            fstype: fstype.to_owned(),
+        })
+    } else {
+        Ok(())
+    }
+}

--- a/src/init/logging.rs
+++ b/src/init/logging.rs
@@ -1,0 +1,68 @@
+use log::{Level, SetLoggerError};
+use simplelog::SimpleLogger;
+use syslog::{BasicLogger, Facility, Formatter3164};
+
+const AURAED_SYSLOG_NAME: &str = "auraed";
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum LoggingError {
+    #[error("Unable to connect to syslog: {0}")]
+    SysLogConnectionFailure(SetLoggerError),
+    #[error("Unable to setup syslog: {0}")]
+    SysLogSetupFailure(SetLoggerError),
+}
+
+pub(crate) fn init(logger_level: Level) -> Result<(), LoggingError> {
+    match std::process::id() {
+        1 => init_pid1_logging(logger_level),
+        _ => init_syslog_logging(logger_level),
+    }
+}
+
+fn init_syslog_logging(logger_level: Level) -> Result<(), LoggingError> {
+    // Syslog formatter
+    let formatter = Formatter3164 {
+        facility: Facility::LOG_USER,
+        hostname: None,
+        process: AURAED_SYSLOG_NAME.into(),
+        pid: 0,
+    };
+
+    // Initialize the logger
+    let logger_simple = create_logger_simple(logger_level);
+
+    let logger_syslog = match syslog::unix(formatter) {
+        Ok(log_val) => log_val,
+        Err(e) => {
+            panic!("Unable to setup syslog: {:?}", e);
+        }
+    };
+
+    multi_log::MultiLogger::init(
+        vec![logger_simple, Box::new(BasicLogger::new(logger_syslog))],
+        logger_level,
+    )
+    .map_err(LoggingError::SysLogSetupFailure)
+}
+
+// To discuss here https://github.com/aurae-runtime/auraed/issues/24:
+//      The "syslog" logger requires unix sockets.
+//      Syslog assumes that either /dev/log or /var/run/syslog are available [1].
+//      We need to discuss if there is a use case to log via unix sockets,
+//      other than fullfill the requirement of syslog crate.
+//      For now, auraed distinguishes between pid1 system and local (dev environment) logging.
+//      [1] https://docs.rs/syslog/latest/src/syslog/lib.rs.html#232-243
+fn init_pid1_logging(logger_level: Level) -> Result<(), LoggingError> {
+    // Initialize the logger
+    let logger_simple = create_logger_simple(logger_level);
+
+    multi_log::MultiLogger::init(vec![logger_simple], logger_level)
+        .map_err(LoggingError::SysLogConnectionFailure)
+}
+
+fn create_logger_simple(logger_level: Level) -> Box<SimpleLogger> {
+    SimpleLogger::new(
+        logger_level.to_level_filter(),
+        simplelog::Config::default(),
+    )
+}

--- a/src/init/network/sriov.rs
+++ b/src/init/network/sriov.rs
@@ -1,0 +1,49 @@
+use std::num::ParseIntError;
+use std::{cmp, fs, io};
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum SriovError {
+    #[error("Failed to get sriov capabilities of device {iface}")]
+    GetCapabilitiesFailure { iface: String, source: io::Error },
+    #[error("Failed to parse sriov capabilities {capabilities}")]
+    ParseCapabilitiesFailure { capabilities: String, source: ParseIntError },
+}
+
+// Create max(limit, max possible sriov for given iface) sriov devices for the given iface
+#[allow(dead_code)]
+pub(crate) fn setup_sriov(iface: &str, limit: u16) -> Result<(), SriovError> {
+    if limit == 0 {
+        return Ok(());
+    }
+
+    let sriov_totalvfs = get_sriov_capabilities(iface).map_err(|e| {
+        SriovError::GetCapabilitiesFailure {
+            iface: iface.to_owned(),
+            source: e,
+        }
+    })?;
+
+    let sriov_totalvfs =
+        sriov_totalvfs.trim_end().parse::<u16>().map_err(|e| {
+            SriovError::ParseCapabilitiesFailure {
+                capabilities: sriov_totalvfs,
+                source: e,
+            }
+        })?;
+
+    let num = cmp::min(limit, sriov_totalvfs);
+
+    fs::write(
+        format!("/sys/class/net/{}/device/sriov_numvfs", iface),
+        num.to_string(),
+    )
+    .expect("Unable to write file");
+    Ok(())
+}
+
+fn get_sriov_capabilities(iface: &str) -> Result<String, io::Error> {
+    fs::read_to_string(format!(
+        "/sys/class/net/{}/device/sriov_totalvfs",
+        iface
+    ))
+}

--- a/src/init/system_runtime.rs
+++ b/src/init/system_runtime.rs
@@ -1,0 +1,202 @@
+use crate::init::network::{
+    add_address, add_route_v6, set_link_up, show_network_info,
+};
+use crate::init::power::spawn_thread_power_button_listener;
+use crate::init::{fs, logging, InitError, BANNER};
+use anyhow::anyhow;
+use ipnetwork::{IpNetwork, Ipv6Network};
+use log::{error, info, trace, Level};
+use netlink_packet_route::RtnlMessage;
+use rtnetlink::new_connection;
+use rtnetlink::proto::Connection;
+use std::path::Path;
+use tonic::async_trait;
+
+const LOOPBACK_DEV: &str = "lo";
+
+const LOOPBACK_IPV6: &str = "::1";
+const LOOPBACK_IPV6_SUBNET: &str = "/128";
+
+const LOOPBACK_IPV4: &str = "127.0.0.1";
+const LOOPBACK_IPV4_SUBNET: &str = "/8";
+
+const DEFAULT_NET_DEV: &str = "eth0";
+const DEFAULT_NET_DEV_IPV6: &str = "fe80::2";
+const DEFAULT_NET_DEV_IPV6_SUBNET: &str = "/64";
+
+const POWER_BUTTON_DEVICE: &str = "/dev/input/event0";
+
+#[async_trait]
+pub(crate) trait SystemRuntime {
+    async fn init(self, logger_level: Level) -> Result<(), InitError>;
+}
+
+pub(crate) struct Pid1SystemRuntime;
+
+impl Pid1SystemRuntime {
+    async fn init_network(
+        &self,
+        connection: Connection<RtnlMessage>,
+        handle: &rtnetlink::Handle,
+    ) {
+        tokio::spawn(connection);
+
+        trace!("configure {}", LOOPBACK_DEV);
+        match self.configure_loopback(handle).await {
+            Ok(_) => {
+                info!("Successfully configured {}", LOOPBACK_DEV);
+            }
+            Err(e) => {
+                error!("Failed to setup loopback device. Error={}", e);
+            }
+        }
+
+        trace!("configure {}", DEFAULT_NET_DEV);
+
+        match self.configure_nic(handle).await {
+            Ok(_) => {
+                info!("Successfully configured {}", DEFAULT_NET_DEV);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to configure NIC {}. Error={}",
+                    DEFAULT_NET_DEV, e
+                );
+            }
+        }
+
+        show_network_info(handle).await;
+    }
+
+    async fn configure_loopback(
+        &self,
+        handle: &rtnetlink::Handle,
+    ) -> anyhow::Result<()> {
+        if let Ok(ipv6) = format!("{}{}", LOOPBACK_IPV6, LOOPBACK_IPV6_SUBNET)
+            .parse::<IpNetwork>()
+        {
+            if let Err(e) = add_address(LOOPBACK_DEV, ipv6, handle).await {
+                return Err(anyhow!("Failed to add ipv6 address to loopback device {}. Error={}", LOOPBACK_DEV, e));
+            };
+        }
+
+        if let Ok(ipv4) = format!("{}{}", LOOPBACK_IPV4, LOOPBACK_IPV4_SUBNET)
+            .parse::<IpNetwork>()
+        {
+            if let Err(e) = add_address(LOOPBACK_DEV, ipv4, handle).await {
+                return Err(anyhow!("Failed to add ipv4 address to loopback device {}. Error={}", LOOPBACK_DEV, e));
+            }
+        };
+
+        if let Err(e) = set_link_up(handle, LOOPBACK_DEV).await {
+            return Err(anyhow!(
+                "Failed to set link up for device {}. Error={}",
+                LOOPBACK_DEV,
+                e
+            ));
+        }
+
+        Ok(())
+    }
+
+    // TODO: design network config struct
+    async fn configure_nic(
+        &self,
+        handle: &rtnetlink::Handle,
+    ) -> anyhow::Result<()> {
+        if let Ok(ipv6) =
+            format!("{}{}", DEFAULT_NET_DEV_IPV6, DEFAULT_NET_DEV_IPV6_SUBNET)
+                .parse::<Ipv6Network>()
+        {
+            if let Err(e) = add_address(DEFAULT_NET_DEV, ipv6, handle).await {
+                return Err(anyhow!(
+                    "Failed to add ipv6 address to device {}. Error={}",
+                    DEFAULT_NET_DEV,
+                    e
+                ));
+            }
+
+            if let Err(e) = set_link_up(handle, DEFAULT_NET_DEV).await {
+                return Err(anyhow!(
+                    "Failed to set link up for device {}. Error={}",
+                    DEFAULT_NET_DEV,
+                    e
+                ));
+            }
+
+            if let Ok(destv6) = "::/0".to_string().parse::<Ipv6Network>() {
+                if let Err(e) =
+                    add_route_v6(&destv6, DEFAULT_NET_DEV, &ipv6, handle).await
+                {
+                    return Err(anyhow!(
+                        "Failed to add ipv6 route to device {}. Error={}",
+                        DEFAULT_NET_DEV,
+                        e
+                    ));
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    fn spawn_system_runtime_threads(&self) {
+        // ---- MAIN DAEMON THREAD POOL ----
+        // TODO: https://github.com/aurae-runtime/auraed/issues/33
+        match spawn_thread_power_button_listener(Path::new(POWER_BUTTON_DEVICE))
+        {
+            Ok(_) => {
+                info!("Spawned power button device listener");
+            }
+            Err(e) => {
+                error!(
+                    "Failed to spawn power button device listener. Error={}",
+                    e
+                );
+            }
+        }
+
+        // ---- MAIN DAEMON THREAD POOL ----
+    }
+}
+
+#[async_trait]
+impl SystemRuntime for Pid1SystemRuntime {
+    async fn init(self, logger_level: Level) -> Result<(), InitError> {
+        println!("{}", BANNER);
+
+        logging::init(logger_level)?;
+        trace!("Logging started");
+
+        trace!("Configure filesystem");
+        fs::mount_vfs("none", "/dev", "devtmpfs")?;
+        fs::mount_vfs("none", "/sys", "sysfs")?;
+        fs::mount_vfs("proc", "/proc", "proc")?;
+
+        trace!("configure network");
+        //show_dir("/sys/class/net/", false); // Show available network interfaces
+        match new_connection() {
+            Ok((connection, handle, ..)) => {
+                self.init_network(connection, &handle).await;
+            }
+            Err(e) => {
+                error!("Could not initialize network! Error={}", e);
+            }
+        };
+
+        self.spawn_system_runtime_threads();
+
+        trace!("init of auraed as pid1 done");
+        Ok(())
+    }
+}
+
+pub(crate) struct PidGt1SystemRuntime;
+
+#[async_trait]
+impl SystemRuntime for PidGt1SystemRuntime {
+    async fn init(self, logger_level: Level) -> Result<(), InitError> {
+        logging::init(logger_level)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Definitely not where I would want to end up, but this seemed like a good place to do the pr/get a review. If the organization makes sense, I (with some guidance) or someone else can attempt to continue with network, fileio, and power.

Steps taken:
- Moved all the init code into the init module (specifically SystemRuntime)
- Attempted to architect the code in a more foolproof way (e.g., non-pid1 process cannot call pid1 init code)
- Divided related code into smaller mods
- Slimed down init's top level mod, and expose the minimum necessary
- Reduced the reliance on anyhow in favor of custom errors using thiserror