### PR TITLE
Add go_package headers to stdlib/v0 protos and removed missing doc links

### DIFF
--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -4,9 +4,7 @@ Read the original [whitepaper](https://docs.google.com/document/d/1dA591eipsgWeA
 
 ### Subsystem Documentation
 
-- [Subsystem Specification](https://github.com/aurae-runtime/api/tree/main/spec#aurae-api-specification)
-    - [Proposing a New Subsystem](https://github.com/aurae-runtime/api/tree/main/spec#proposing-a-new-subsystem)
-    - [Requesting a Change (RFC) to an existing subsystem](https://github.com/aurae-runtime/api/tree/main/spec#requesting-a-change-rfc-to-an-existing-subsystem)
+[//]: # (TODO - Include links to subsystem docs when they are reintroduced)
 
 ### API Convention
 

--- a/stdlib/v0/meta.proto
+++ b/stdlib/v0/meta.proto
@@ -32,6 +32,8 @@ syntax = "proto3";
 
 package meta;
 
+option go_package = "github.com/aurae-runtime/client-go/pkg/stdlib/v0/meta";
+
 /// Status represents the state of an object within Aurae.
 /// The status Enum has special meaning used for each value.
 enum Status {

--- a/stdlib/v0/observe.proto
+++ b/stdlib/v0/observe.proto
@@ -32,6 +32,8 @@ syntax = "proto3";
 
 package observe;
 
+option go_package = "github.com/aurae-runtime/client-go/pkg/stdlib/v0/observe";
+
 import "meta.proto";
 
 service Observe {

--- a/stdlib/v0/runtime.proto
+++ b/stdlib/v0/runtime.proto
@@ -32,6 +32,8 @@ syntax = "proto3";
 
 package runtime;
 
+option go_package = "github.com/aurae-runtime/client-go/pkg/stdlib/v0/runtime";
+
 import "meta.proto";
 
 /// Runtime is a synchronous and immediate subsystem.

--- a/stdlib/v0/schedule.proto
+++ b/stdlib/v0/schedule.proto
@@ -32,7 +32,7 @@ syntax = "proto3";
 
 package runtime;
 
-import "meta.proto";
+option go_package = "github.com/aurae-runtime/client-go/pkg/stdlib/v0/schedule";
 
 service Schedule {
 


### PR DESCRIPTION
- Added `option go_package` headers to make building the Go client a whole lot easier
- Removed the dead links to docs in the old api repo